### PR TITLE
add kube inline component

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -12,9 +12,30 @@ components:
       dockerfile:
         uri: catalog.Dockerfile
         buildContext: "4.13"
-  - name: kubernetes
+  - name: outerloop-deploy
     kubernetes:
-      inlined: placeholder
+      inlined: |-
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: fbc
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: fbc
+          template:
+            metadata:
+              labels:
+                app: fbc
+            spec:
+              containers:
+                - name: fbc
+                  image: fbc:latest
+                  resources:
+                    limits:
+                      memory: "1024Mi"
+                      cpu: "500m"
     attributes:
       deployment/container-port: 50051
       deployment/cpuRequest: "100m"
@@ -25,3 +46,14 @@ commands:
   - id: build-image
     apply:
       component: image-build
+  - id: deployk8s
+    apply:
+      component: outerloop-deploy
+  - id: deploy
+    composite:
+      commands:
+        - build-image
+        - deployk8s
+      group:
+        kind: deploy
+        isDefault: true


### PR DESCRIPTION
add kube line component to ensure the devfile is a valid outerloop definition for the e2e test. See detailed discussion: https://redhat-internal.slack.com/archives/C02HZRGKDEY/p1680778911884259